### PR TITLE
Watcher tests

### DIFF
--- a/src/runtime/composables/cwa.ts
+++ b/src/runtime/composables/cwa.ts
@@ -1,3 +1,4 @@
 import { useNuxtApp } from '#imports'
+import type Cwa from '#cwa/runtime/cwa'
 
-export const useCwa = () => useNuxtApp().$cwa
+export const useCwa = () => useNuxtApp().$cwa as Cwa

--- a/src/runtime/templates/components/core/ResourceLoader.vue
+++ b/src/runtime/templates/components/core/ResourceLoader.vue
@@ -85,14 +85,21 @@ const resolvedComponent = computed(() => {
   return resourceUiComponent.value
 })
 
-onMounted(() => {
-  watch(() => [hasSilentError, resource], async ([hasSilentError, resource]) => {
+const methods = {
+  getFetchResourceDeps () {
+    return [hasSilentError, resource]
+  },
+  async fetchResource ([hasSilentError, resource]) {
     if (resource.value.apiState.ssr && !resource.value?.data && hasSilentError.value) {
       await $cwa.fetchResource({
         path: props.iri
       })
     }
-  }, {
+  }
+}
+
+onMounted(() => {
+  watch(methods.getFetchResourceDeps, methods.fetchResource, {
     immediate: true
   })
 })


### PR DESCRIPTION
- [x] typed `useCwa` for better TS DX
- [x] moved watcher logic into methods, covered them with tests, covered watchers meta with tests
- [x] moved watcher inside mounted hook for `ComponentGroup`